### PR TITLE
Fix Adobe-algorithm key generation

### DIFF
--- a/src/glyphIgo.py
+++ b/src/glyphIgo.py
@@ -1020,7 +1020,7 @@ class GlyphIgo:
                 k = k.replace(u"urn:uuid:", "")
                 k = k.replace(u"-", "")
                 k = k.replace(u":", "")
-                d = k 
+                d = k.decode("hex")
             return str(d)
  
         f = open(self.__args.font, 'rb')


### PR DESCRIPTION
Fixes #12

(Prior to this commit, glyphIgo was using the ascii "values" of the key's characters rather than the hex values those characters represent).

HTH, J